### PR TITLE
Old scribe repo import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# Scribe
+# scribe
+
+A tool for assisting with support case organization.
+
+## Features
+
+* Watches for new files such as screenshots, downloads, and related support case files and keeps them together for later reference.
+
+Go Version: 1.14
+
+### MVP
+
+* Read defaults from ENV/Config
+
+* Implement file system watcher

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"github.com/alecthomas/kong"
+)
+
+var App struct {
+
+}
+
+type watch struct {
+	Path   string `arg name:"path" type:"path" help:"Path to watch."`
+	target string `type:"path" name:"target"`
+} `cmd help: "Watch designated folder."`
+
+func (w *watch) Run() error {
+	/*
+	TODO: 	 Get information for $PATH and $TARGET directory
+			 * Check if target dir is empty, default to zero-value?
+			 * Create watch function, first validate input and
+			 * then pass to watch function
+	*/
+
+	return nil
+}
+
+func main() {
+	// Context
+	ctx := kong.Parse(&App)
+	switch ctx.Command() {
+	case "watch":
+	default:
+		panic(ctx.Command())
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/pi-impala/scribe
+
+go 1.14
+
+require (
+	github.com/alecthomas/kong v0.2.5
+)


### PR DESCRIPTION
- [x] Updated README with cursory list of MVP features
- [x] Standard Go focused gitignore. Nothing to call out.
- [x] Updated module file to match new org and repo name. Used v2 Syntax
- [x] Added existing *unworking* code as-is to this repo.