### PR TITLE
Create go.yml

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,41 @@
+name: Go
+
+on:
+  push:
+    branches: [ master, dev-feature ]
+  pull_request:
+    branches: [ master, dev-feature ]
+
+jobs:
+
+  build:
+    strategy:
+      matrix:
+        go-version: [1.12.x,1.13.x, 1.14.x]
+        platform: [ubuntu-latest, macos-latest]
+    runs-on: ${{matrix.platform}}
+    name: Build
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{matrix.go-version}}
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+        if [ -f Gopkg.toml ]; then
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure
+        fi
+
+    - name: Build
+      run: go build -v .
+
+    - name: Test
+      run: go test -v ./...


### PR DESCRIPTION
Added GitHub actions CI/CD. There was a predefined template for go projects already, and I just edited the script to add macos and ubuntu to tested platforms, and go versions 1.12.x, 1.13.x, and 1.14.x to the build.