### PR TITLE
Makebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+# Go build system commands
+GOCMD=go
+GOBUILD=$(GOCMD) build
+GOTEST=$(GOCMD) test
+GOCLEAN=$(GOCMD) clean
+GOTIDY=$(GOCMD) mod tidy
+
+# Binary specific parameters
+BIN_NAME=scribe
+
+all: test build
+
+test:
+	$(GOTEST) -v ./...
+
+build:
+	$(GOTIDY)
+	$(GOBUILD) -o $(BIN_NAME) -v 
+
+clean:
+	$(GOCLEAN)
+
+build-prod-linux: clean test
+	$(GOTIDY)
+	GOOS=linux GOARCH=amd64 $(GOBUILD) -ldflags="-s -w" -o $(BIN_NAME) -v
+	upx --brute $(BIN_NAME)
+
+build-prod-darwin: clean test
+	$(GOTIDY)
+	GOOS=darwin GOARCH=amd64 $(GOBUILD) -ldflags="-s -w" -o $(BIN_NAME) -v
+	upx --brute $(BIN_NAME)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ A tool for assisting with support case organization.
 
 Go Version: 1.14
 
-### MVP
+## Build from source
+### Requirements for production builds
+* make (tested with GNU Make 4.1 x86_64-pc-linux-gnu)
+* upx (tested with upx 3.91 UCL data compression library 1.03 LZMA SDK version 9.22 beta)
 
-* Read defaults from ENV/Config
-
-* Implement file system watcher
+Run ```make build-prod-linux``` or ```make build-prod-darwin```
+### Dev builds
+Run ```make build``` or just ```go build```

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -1,0 +1,96 @@
+package notifier
+
+import (
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/pkg/errors"
+)
+
+type Notifier interface {
+	io.Closer
+	Notify(exts []string, paths ...string) (<-chan Event, <-chan error, error)
+}
+
+type Event interface {
+	Path() string
+}
+
+type event struct {
+	path string
+}
+
+func newEvent(path string) *event {
+	return &event{
+		path,
+	}
+}
+
+func (e *event) Path() string {
+	return e.path
+}
+
+type notifier struct {
+	watcher *fsnotify.Watcher
+	exts    []string
+	events  chan Event
+	errs    chan error
+}
+
+func New() (*notifier, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create watcher")
+	}
+
+	return &notifier{
+		watcher: watcher,
+		exts:    []string{},
+		events:  make(chan Event),
+		errs:    make(chan error),
+	}, nil
+}
+
+func (n *notifier) Close() error {
+	return n.watcher.Close()
+}
+
+func (n *notifier) Notify(exts []string, paths ...string) (<-chan Event, <-chan error, error) {
+	n.exts = exts
+	for _, path := range paths {
+		if err := n.watcher.Add(path); err != nil {
+			return n.events, n.errs, errors.Wrapf(err, "failed to  add path %s", path)
+		}
+	}
+	// ...TODO: flush out
+	go func() {
+		for {
+			select {
+			case event, ok := <-n.watcher.Events:
+				if !ok {
+					n.errs <- errors.New("channel error")
+					return
+				}
+				if event.Op&fsnotify.Create == fsnotify.Create {
+					_, filename := filepath.Split(event.Name)
+					for _, ext := range n.exts {
+						if strings.HasSuffix(filename, ext) || len(n.exts) == 0 {
+							evt := newEvent(event.Name)
+							n.events <- evt
+							break
+						}
+					}
+				}
+			case err, ok := <-n.watcher.Errors:
+				if !ok {
+					n.errs <- errors.New("channel error")
+					return
+				}
+				n.errs <- err
+			}
+		}
+	}()
+	return n.events, n.errs, nil
+}


### PR DESCRIPTION
I added a Makefile to simplify the production build that will be used for distribution, and updated the README with the new build from source instructions.

Motivation: the binary size on my linux pc is ~13Mb when using just go build. This was brought down to ~2.7Mb by adding ldflags to strip away unneeded symbols and then using the upx packing tool to compress the artifact. I don't think anyone using this tool would care about having a 13Mb binary on their system, but as we add more features I think it would be good to try to keep the size down.

